### PR TITLE
Allow multiple topic subscriptions

### DIFF
--- a/tests/from_mqtt_events.yml
+++ b/tests/from_mqtt_events.yml
@@ -1,4 +1,6 @@
-subscribe-topic: in_topic
+subscribe-topic:
+  - in_topic
+  - in_topic2
 
 from-mqtt:
   # the AFB API to call on requests

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -13,6 +13,7 @@ import paho.mqtt.client as mqtt
 
 OUT_TOPIC = "out_topic"
 IN_TOPIC = "in_topic"
+IN_TOPIC2 = "in_topic2"
 
 # MQTT client
 mqttc = None
@@ -55,7 +56,7 @@ def on_mqtt_connect(client, userdata, flags, reason_code, properties):
     mqtt_state = "ready"
 
 
-def mqtt_publish(data: dict):
+def mqtt_publish(data: dict, topic=IN_TOPIC):
     return mqttc.publish(IN_TOPIC, json.dumps(data).encode("utf-8"))
 
 
@@ -250,7 +251,7 @@ class Tests:
             assert raised
 
         r = libafb.callsync(
-            self.binder, "from_mqtt", "subscribe_events", ["event1", "event2"]
+            self.binder, "from_mqtt", "subscribe_events", ["event1", "event2", "eventA"]
         )
         assert r.status == 0
 
@@ -265,7 +266,11 @@ class Tests:
 
             return test_event_cb_
 
-        for event_name in ("event1", "event2"):
+        for topic_name, event_name in (
+            (IN_TOPIC, "event1"),
+            (IN_TOPIC, "event2"),
+            (IN_TOPIC2, "eventA"),
+        ):
             libafb.evthandler(
                 self.binder,
                 {
@@ -283,6 +288,7 @@ class Tests:
                     "name": event_name,
                     "data": "toto",
                 },
+                topic=topic_name,
             )
 
             for _ in range(5):


### PR DESCRIPTION
This allows subscription to multiple MQTT
channels. However messages on all topics must
share the same structure.

A better evolution would be to support multiple
configurations (i.e. repeat publish / subscribe
topic for each message definition) so that we
could have different message structures on a topic or on multiple topics.